### PR TITLE
Reduce envrionment.yml dependencies

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -2,24 +2,15 @@ name: clliaa
 channels:
   - defaults
 dependencies:
-  - ca-certificates=2019.1.23=0
-  - certifi=2019.3.9=py37_0
-  - libedit=3.1.20181209=hc058e9b_0
-  - libffi=3.2.1=hd88cf55_4
-  - libgcc-ng=8.2.0=hdf63c60_1
-  - libsodium=1.0.16=h1bed415_0
-  - libstdcxx-ng=8.2.0=hdf63c60_1
-  - ncurses=6.1=he6710b0_1
-  - openssl=1.1.1b=h7b6447c_1
-  - pip=19.1.1=py37_0
-  - python=3.7.3=h0371630_0
-  - readline=7.0=h7b6447c_5
-  - setuptools=41.0.1=py37_0
-  - sqlite=3.28.0=h7b6447c_0
-  - tk=8.6.8=hbc83047_0
-  - wheel=0.33.4=py37_0
-  - xz=5.2.4=h14c3975_4
-  - zlib=1.2.11=h7b6447c_3
+  - libgcc-ng=8.2
+  - libsodium=1.0
+  - libstdcxx-ng=8.2
+  - ncurses=6.1
+  - pip
+  - python=3
+  - readline=7
+  - setuptools
+  - tk=8.6
   - pip:
     - backcall==0.1.0
     - click==7.0
@@ -48,14 +39,11 @@ dependencies:
     - numpy==1.16.3
     - parso==0.5.1
     - pexpect==4.7.0
-    - pickleshare==0.7.5
     - prompt-toolkit==2.0.9
-    - ptyprocess==0.6.0
     - pygdbmi==0.9.0.1
     - pyglet==1.3.2
     - pygments==2.4.2
     - pyparsing==2.4.0
-    - python-dateutil==2.8.0
     - python-engineio==3.5.2
     - python-socketio==4.0.2
     - pyzmq==18.0.1


### PR DESCRIPTION
The definition of specific builds in the dependencies is dangerous and leads to problems when packages move on. The environment file should only contain top level dependencies that are explicitly required. These dependencies may pull in deeper ones if they need, but it's not for this env to define which that should be. Also the dependencies should only specify to the actual requirements, i.e. probably it is not necessary to have Python "3.7.3=h0371630_0" but any "3.7" would work, maybe even any "3".
This is aimed to fix #3 but I don't have a Mac and can't try. Maybe @jakobj could also have a look if there is more unnecessary dependencies to cut.